### PR TITLE
Improve OPC UA Sensor Event Distribution and Add Diagnostics

### DIFF
--- a/virtual_assets/opcua_sensor/README.md
+++ b/virtual_assets/opcua_sensor/README.md
@@ -63,6 +63,19 @@ If `NUM_SENSORS=2`, the structure looks like this (under `0:Root/0:Objects`):
 * **OverTemperatureAlarm** – Triggered when temperature exceeds 90% of the configured range.
 * **SensorFaultCondition** – Triggered around `SENSOR_FAULT_AVG` intervals to simulate random sensor errors.
 
+### Timing behavior
+
+Each sensor is assigned a random initial phase when the simulator starts.
+This distributes updates across the reporting interval and avoids startup bursts when simulating large numbers of sensors.
+
+Subsequent update intervals vary by ±20% around the configured average values (`TEMP_SLEEP_AVG`, `HUM_SLEEP_AVG`, and `SENSOR_FAULT_AVG`).
+
+### Event distribution diagnostics
+
+When running the simulator, periodic log messages report the average number of events generated per scheduler cycle.
+
+These diagnostics help verify that events are evenly distributed across time and that large bursts are not created when simulating hundreds of sensors. They are particularly useful when evaluating the impact of scheduler settings and validating load-generation behavior before connecting the simulator to Kafka or other downstream services.
+
 ## 🚀 Deploying
 
 The virtual sensor can be deployed on a local machine or in the OpenFactory cluster.

--- a/virtual_assets/opcua_sensor/opcua_device.py
+++ b/virtual_assets/opcua_sensor/opcua_device.py
@@ -256,14 +256,26 @@ async def main():
         logger.info("---------------------------------------------------")
 
         # Timers per sensor
-        next_temp_time = {s["name"]: time.time() for s in sensors}
-        next_hum_time = {s["name"]: time.time() for s in sensors}
+        next_temp_time = {
+            s["name"]: time.time() + random.uniform(0, TEMP_SLEEP_AVG)
+            for s in sensors
+        }
+        next_hum_time = {
+            s["name"]: time.time() + random.uniform(0, HUM_SLEEP_AVG)
+            for s in sensors
+        }
         next_fault_time = {
-            s["name"]: time.time() + random.uniform(0.8 * SENSOR_FAULT_AVG, 1.2 * SENSOR_FAULT_AVG)
+            s["name"]: time.time() + random.uniform(0, SENSOR_FAULT_AVG)
             for s in sensors
         }
 
         try:
+            last_report = time.time()
+            nbr_cycles = 0
+            fired_temp = 0
+            fired_hum = 0
+            fired_fault = 0
+
             while True:
                 now = time.time()
 
@@ -281,30 +293,48 @@ async def main():
                             reported_temp = temp_c
 
                         await s["temp"].write_value(reported_temp)
-                        logger.info(f"{s['name']} Temperature: {reported_temp}°{unit}")
+                        logger.debug(f"{s['name']} Temperature: {reported_temp}°{unit}")
+                        fired_temp += 1
 
                         if temp_c > (TEMP_MIN + 0.9 * (TEMP_MAX - TEMP_MIN)):
                             await s["overtemp_alarm"].trigger()
-                            logger.info(f"{s['name']} OverTemperatureAlarm triggered")
+                            logger.debug(f"{s['name']} OverTemperatureAlarm triggered")
 
-                        next_temp_time[s["name"]] = now + random.uniform(0.8 * TEMP_SLEEP_AVG, 1.2 * TEMP_SLEEP_AVG)
+                        next_temp_time[s["name"]] += random.uniform(0.8 * TEMP_SLEEP_AVG, 1.2 * TEMP_SLEEP_AVG)
 
                     # Humidity
                     if now >= next_hum_time[s["name"]]:
                         current_hum = round(random.uniform(HUM_MIN, HUM_MAX), 1)
                         await s["hum"].write_value(current_hum)
-                        logger.info(f"{s['name']} Humidity: {current_hum}%")
-
-                        next_hum_time[s["name"]] = now + random.uniform(0.8 * HUM_SLEEP_AVG, 1.2 * HUM_SLEEP_AVG)
+                        logger.debug(f"{s['name']} Humidity: {current_hum}%")
+                        fired_hum += 1
+                        next_hum_time[s["name"]] += random.uniform(0.8 * HUM_SLEEP_AVG, 1.2 * HUM_SLEEP_AVG)
 
                     # Fault
                     if now >= next_fault_time[s["name"]]:
                         await s["fault_alarm"].trigger()
-                        logger.info(f"{s['name']} SensorFaultCondition triggered")
-                        next_fault_time[s["name"]] = now + random.uniform(0.8 * SENSOR_FAULT_AVG, 1.2 * SENSOR_FAULT_AVG)
+                        logger.debug(f"{s['name']} SensorFaultCondition triggered")
+                        fired_fault += 1
+                        next_fault_time[s["name"]] += random.uniform(0.8 * SENSOR_FAULT_AVG, 1.2 * SENSOR_FAULT_AVG)
+
+                # Log number of fired events
+                nbr_cycles += 1
+                if now - last_report >= 1.0:
+                    logger.info(
+                        f"Avg number of fired events per batch: "
+                        f"temp={fired_temp/nbr_cycles:.2f} "
+                        f"hum={fired_hum/nbr_cycles:.2f} "
+                        f"fault={fired_fault/nbr_cycles:.2f} "
+                        f"total={(fired_temp+fired_hum+fired_fault)/nbr_cycles:.2f}"
+                    )
+                    last_report = now
+                    fired_temp = 0
+                    fired_hum = 0
+                    fired_fault = 0
+                    nbr_cycles = 0
 
                 # Sleep a short time to avoid busy-waiting
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0.01)
 
         finally:
             logger.info("Server stopped")


### PR DESCRIPTION
Improve the OPC UA sensor simulator to better distribute events when large numbers of sensors are deployed and add diagnostics to validate event distribution.

## Changes

### Randomize initial sensor phase

Initialize temperature, humidity, and fault timers with a random offset within their respective reporting intervals.

This prevents all sensors from emitting their first event immediately after startup and distributes events across the reporting period.

### Preserve jittered update intervals

Continue using jittered update intervals around the configured averages:

* Temperature: `TEMP_SLEEP_AVG ±20%`
* Humidity: `HUM_SLEEP_AVG ±20%`
* Fault events: `SENSOR_FAULT_AVG ±20%`

This avoids long-term synchronization while maintaining predictable average reporting rates.

### Improve event scheduling resolution

Reduce the scheduler sleep interval from 100 ms to 10 ms.

This decreases scheduler-induced batching and results in a smoother event stream when simulating hundreds of sensors.

### Add event distribution diagnostics

Add periodic logging of the average number of events generated per scheduler cycle.

Example:

```text
Avg events/batch: temp=2.47, hum=1.23, fault=0.25, total=3.95
```

These diagnostics make it easier to verify that events remain evenly distributed and that no significant bursts are introduced by the simulator.

## Documentation

Update the README to document:

* Randomized initial sensor phase.
* Jittered reporting intervals.
* Event distribution diagnostics and their purpose.

## Validation

The simulator was tested with 500 sensors.

Observed event counts per scheduling cycle are consistent with the expected distribution and no startup synchronization effects were observed after introducing randomized initial phases.

This version is written as a PR description: present tense for what the PR does, concise change list, and a validation section at the end.
